### PR TITLE
Add support for command-line options

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var which = require('shelljs').which;
 
 function createSlimPreprocessor(config, logger) {
   var log, slimCommand, slimCommandAbsolute;
+  var slimCommandArgs = [];
 
   config = config || {};
   log = logger.create('preprocessor.slim');
@@ -21,6 +22,11 @@ function createSlimPreprocessor(config, logger) {
     throw new Error("slimrb command not found");
   }
 
+  if(typeof(config.slimrbOption) === 'string') {
+    log.debug('Passing args to slim command (%s).', config.slimrbOption);
+    slimCommandArgs.push(config.slimrbOption);
+  }
+
   return function(content, file, done) {
     var child, html, path, hadError;
 
@@ -28,7 +34,7 @@ function createSlimPreprocessor(config, logger) {
 
     path = file.originalPath;
     html = '';
-    child = spawn(slimCommandAbsolute, [path]);
+    child = spawn(slimCommandAbsolute, slimCommandArgs.concat(path));
 
     // Handle an error from stderr, which would be a slim syntax error
     child.stderr.on('data', function (buf) {

--- a/test/fixtures/variable.slim
+++ b/test/fixtures/variable.slim
@@ -1,0 +1,2 @@
+p Foo: #{foo}!
+p Bar: #{bar}!

--- a/test/slim2html.spec.coffee
+++ b/test/slim2html.spec.coffee
@@ -57,6 +57,17 @@ describe 'preprocessors slim2html', ->
       expect(result).to.equal('<h1>Hello</h1><div class="dece">And welcome!</div>\n')
       done()
 
+  it 'allows configuring the path of the slimrb binary with the cli options', (done) ->
+    file = new File 'test/fixtures/variable.slim'
+    slimData =
+      foo: "Foooo"
+      bar: "Baaar"
+    slimDataJsonStr = JSON.stringify(slimData)
+    process = slim2html({ slimrb: slimCommand, slimrbOption: '-l ' + slimDataJsonStr }, logger)
+    process '', file, (err, result) ->
+      expect(result).to.equal('<p>Foo: Foooo!</p><p>Bar: Baaar!</p>\n')
+      done()
+
   it 'throws and logs an error given an invalid slim command configuration', (done) ->
     file = new File 'test/fixtures/index.slim'
     expect( ->


### PR DESCRIPTION
In the changes, I've added `config.slimrbOption`, because it's possible to pass data via command-line from slim v3.0.2:

```bash
$ echo 'p Hello, #{name}!!' > hello.slim
$ slimrb --locals '{"name": "Bob"}' hello.slim
<p>Hello, Bob!!</p>
```

We can configure it as below:

```javascript
// karma.conf.js
module.exports = function(config) {
  var slimData = {
    'name': 'Bob'
  };

  config.set({
    preprocessors: {
      '**/*.slim': ['slim']
    },

    slimPreprocessor: {
      slimrbOption: "-l " + JSON.stringify(slimData)
    },

    files: [ 'hello.slim' ]
  });
};
```

See also: https://github.com/slim-template/slim/blob/166831c0cad5c74305c756e107e326df0d4cbb7d/CHANGES#L3